### PR TITLE
patch 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 2.1.1 (2016-10-06)
+
+Bugfixes:
+
+    - Fix bug in `participates_in?` helper that prevented it from working when the `variation_id` was sent as a symbol.
+    - Fix bug in `EenyMeeny::ExperimentConstraint` that prevented it from working when the `variation_id` was sent as a symbol.
+
 ### 2.1.0 (2016-10-02)
 
 Features:

--- a/eeny-meeny.gemspec
+++ b/eeny-meeny.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/eeny-meeny/version', __FILE__)
 Gem::Specification.new do |s|
   s.name        = 'eeny-meeny'
   s.version     = EenyMeeny::VERSION.dup
-  s.date        = '2016-10-02'
+  s.date        = '2016-10-06'
   s.summary     = "A simple split and smoke testing tool for Rails"
   s.authors     = ["Christian Orthmann"]
   s.email       = 'christian.orthmann@gmail.com'

--- a/lib/eeny-meeny/experiment_helper.rb
+++ b/lib/eeny-meeny/experiment_helper.rb
@@ -7,7 +7,7 @@ module EenyMeeny::ExperimentHelper
     experiment = EenyMeeny::Experiment.find_by_id(experiment_id)
     return unless !experiment.nil? && experiment.active?
     participant_variation_id = read_cookie(EenyMeeny::Cookie.cookie_name(experiment))
-    return if variation_id && variation_id != participant_variation_id
+    return if variation_id && variation_id.to_s != participant_variation_id
     experiment.find_variation(participant_variation_id)
   end
 

--- a/lib/eeny-meeny/routing/experiment_constraint.rb
+++ b/lib/eeny-meeny/routing/experiment_constraint.rb
@@ -13,7 +13,7 @@ module EenyMeeny
       return false unless !@experiment.nil? && @experiment.active?
       participant_variation_id = EenyMeeny::Cookie.read(request.cookie_jar[EenyMeeny::Cookie.cookie_name(@experiment)])
       return false if participant_variation_id.nil? # Not participating in experiment
-      (@variation_id.nil? || @variation_id == participant_variation_id)
+      (@variation_id.nil? || @variation_id.to_s == participant_variation_id)
     end
   end
 end

--- a/lib/eeny-meeny/version.rb
+++ b/lib/eeny-meeny/version.rb
@@ -1,3 +1,3 @@
 module EenyMeeny
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/spec/eeny-meeny/experiment_helper_spec.rb
+++ b/spec/eeny-meeny/experiment_helper_spec.rb
@@ -29,6 +29,29 @@ describe EenyMeeny::ExperimentHelper, experiments: true do
             allow(subject).to receive(:cookies).and_return(request_with_cookie.cookie_jar)
             expect(subject.participates_in?(:my_page)).to be_a EenyMeeny::Variation
           end
+
+          context 'and given a variation id' do
+            let(:request_with_variation_cookie) do
+              request.set_cookie(EenyMeeny::Cookie.create_for_experiment_variation(EenyMeeny::Experiment.find_by_id(:my_page), variation_id: :new).to_s)
+              request
+            end
+
+            context 'that matches the variation id the cookie' do
+              it "returns the user's experiment variation" do
+                allow(subject).to receive(:cookies).and_return(request_with_cookie.cookie_jar)
+                expect(subject.participates_in?(:my_page, variation_id: :new)).to be_a EenyMeeny::Variation
+                expect(subject.participates_in?(:my_page, variation_id: 'new')).to be_a EenyMeeny::Variation
+              end
+            end
+
+            context 'that does not match the variation id the cookie' do
+              it 'returns nil' do
+                allow(subject).to receive(:cookies).and_return(request_with_cookie.cookie_jar)
+                expect(subject.participates_in?(:my_page, variation_id: :old)).to be_nil
+                expect(subject.participates_in?(:my_page, variation_id: 'old')).to be_nil
+              end
+            end
+          end
         end
 
         context 'without an experiment cookie' do

--- a/spec/eeny-meeny/routing/experiment_constraint_spec.rb
+++ b/spec/eeny-meeny/routing/experiment_constraint_spec.rb
@@ -6,7 +6,7 @@ describe EenyMeeny::ExperimentConstraint, experiments: true do
 
   let(:request) do
     session = Rack::MockSession.new(EenyMeeny::Middleware.new(MockRackApp.new))
-    session.set_cookie('eeny_meeny_my_page_v1=IlI%2FGW9IZvayAGQbBOroxIrfr6Z116OJqdjFdrw6FOZXOrinmxQmsKw2a%2Fb8kJFP0Up%2BLr4FACovT9%2Bo0hRdcY0AJtcYqMXC96GDMSwa2HauZbjHw16Q3%2BboSnWjfaEOHmqlyxtPxQwxlr3rsT%2FYblPjqqQ%2FiPbaJUqou3LiMtpVg4V%2FJxJdhn0XJUgFMDaFWXVFYYA6VmJSFUGglhRlbg%3D%3D; path=/; expires=Tue, 11 Oct 2016 13:07:53 -0000; HttpOnly')
+    session.set_cookie('eeny_meeny_my_page_v1=ctRsrHCj21pZt%2FELsjedHRT9GkYOuIdoTwEyP9kxfI7dDS4I9g1nv77j9Umij1P44SCU7Zebdb8mqwLabTrskg%3D%3D; path=/; expires=Sun, 06 Nov 2016 11:26:01 -0000; HttpOnly')
     session
   end
 


### PR DESCRIPTION
### 2.1.1 (2016-10-06)

Bugfixes:

```
- Fix bug in `participates_in?` helper that prevented it from working when the `variation_id` was sent as a symbol.
- Fix bug in `EenyMeeny::ExperimentConstraint` that prevented it from working when the `variation_id` was sent as a symbol.
```
