### PR TITLE
Patch 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.1.3 (2017-08-15)
+
+Bugfixes:
+
+    - Fix issue where the global cookie configuration is not applied to smoke test cookies.
+
 ### 2.1.2 (2017-04-14)
 
 Bugfixes:

--- a/eeny-meeny.gemspec
+++ b/eeny-meeny.gemspec
@@ -3,7 +3,7 @@ require File.expand_path('../lib/eeny-meeny/version', __FILE__)
 Gem::Specification.new do |s|
   s.name        = 'eeny-meeny'
   s.version     = EenyMeeny::VERSION.dup
-  s.date        = '2017-04-14'
+  s.date        = '2017-08-15'
   s.summary     = "A simple split and smoke testing tool for Rails"
   s.authors     = ["Christian Orthmann"]
   s.email       = 'christian.orthmann@gmail.com'

--- a/lib/eeny-meeny/middleware.rb
+++ b/lib/eeny-meeny/middleware.rb
@@ -47,7 +47,7 @@ module EenyMeeny
       if EenyMeeny.config.query_parameters[:smoke_test]
         if query_parameters.key?('smoke_test_id') && (query_parameters['smoke_test_id'] =~ /\A[A-Za-z_]+\z/)
           # Set HTTP_COOKIE header to enable smoke test on first pageview
-          cookie = EenyMeeny::Cookie.create_for_smoke_test(query_parameters['smoke_test_id'])
+          cookie = EenyMeeny::Cookie.create_for_smoke_test(query_parameters['smoke_test_id'], @cookie_config)
           env = add_or_replace_http_cookie(env, cookie)
           new_cookies[cookie.name] = cookie
         end

--- a/lib/eeny-meeny/version.rb
+++ b/lib/eeny-meeny/version.rb
@@ -1,3 +1,3 @@
 module EenyMeeny
-  VERSION = '2.1.2'
+  VERSION = '2.1.3'
 end

--- a/lib/tasks/cookie.rake
+++ b/lib/tasks/cookie.rake
@@ -38,7 +38,7 @@ namespace :eeny_meeny do
       raise "Missing 'smoke_test_id' parameter" if (args['smoke_test_id'].nil? || args['smoke_test_id'].empty?)
       smoke_test_id = args['smoke_test_id']
       version       = args['version'] || 1
-      cookie = EenyMeeny::Cookie.create_for_smoke_test(smoke_test_id, version: version)
+      cookie = EenyMeeny::Cookie.create_for_smoke_test(smoke_test_id, EenyMeeny.config.cookies.merge(version: version))
       puts cookie
     end
   end


### PR DESCRIPTION
### 2.1.3 (2017-08-15)

Bugfixes:

    - Fix issue where the global cookie configuration is not applied to smoke test cookies.