### PR TITLE
Remove non-existing active experiments

### DIFF
--- a/lib/eeny-meeny/models/experiment.rb
+++ b/lib/eeny-meeny/models/experiment.rb
@@ -25,12 +25,12 @@ module EenyMeeny
     end
 
     def self.find_by_cookie_name(cookie_name)
-      return nil unless EenyMeeny.config.experiments
-      return nil unless cookie_name =~ COOKIE_EXPERIMENT_ID_REGEX
-      experiment_id = $1
-      experiment_version = $2
-      experiment = EenyMeeny.config.experiments[experiment_id.to_sym]
-      new(experiment_id, **experiment) if experiment && experiment[:version].to_s == experiment_version
+      return unless cookie_name =~ COOKIE_EXPERIMENT_ID_REGEX
+
+      experiment = find_by_id($1)
+      return unless experiment && experiment.version.to_s == $2
+
+      experiment
     end
 
     def initialize(id, name: '', version: 1, variations: {}, start_at: nil, end_at: nil)

--- a/lib/eeny-meeny/models/experiment.rb
+++ b/lib/eeny-meeny/models/experiment.rb
@@ -1,3 +1,4 @@
+require 'eeny-meeny/models/cookie'
 require 'eeny-meeny/models/variation'
 require 'active_support/time'
 require 'active_support/core_ext/enumerable'


### PR DESCRIPTION
Related to https://github.com/corthmann/eeny-meeny/pull/7/commits/2bdabc8762694cec343436026b66c26fe74eb247

The above change cleans up obsolete experiments, but when we update experiment with active start_at/end_at dates, old experiment cookie won't get deleted and continue to remain.
Cleanup cookies for such case by experiment version, in addition to experiment id.